### PR TITLE
feat: upgrade Java version from 17 to 21 in shared integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
 
       - name: Build CLI
@@ -173,7 +173,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Setup Runtimes
         shell: bash


### PR DESCRIPTION
## Summary

- Update `java-version` from 17 to 21 in both `Setup Java` steps (build and CLI execution)
- Required by trustify-da-java-client which now targets `maven.compiler.release=21` in https://github.com/guacsec/trustify-da-java-client/pull/390

Implements [TC-3969](https://redhat.atlassian.net/browse/TC-3969)

## Test plan

- [ ] Integration tests pass with Java 21 for java language clients
- [ ] JavaScript language clients unaffected (no Java version change for them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)