### PR TITLE
fix(ci): use GITHUB_PATH instead of replacing PATH in setup-runtime

### DIFF
--- a/shared-scripts/setup-runtime.sh
+++ b/shared-scripts/setup-runtime.sh
@@ -70,8 +70,8 @@ case "$RUNTIME" in
         # Set up Go 1.21 as default (keg-only formula)
         export PATH="/opt/homebrew/opt/go@1.21/bin:$PATH"
         export GOROOT="/opt/homebrew/opt/go@1.21/libexec"
-        # Use GITHUB_PATH to prepend without clobbering the existing PATH
-        echo "/opt/homebrew/opt/go@1.21/bin" >> $GITHUB_PATH
+        # Persist environment variables for subsequent steps
+        echo "PATH=$PATH" >> $GITHUB_ENV
         echo "GOROOT=$GOROOT" >> $GITHUB_ENV
         ;;
       *)
@@ -89,8 +89,7 @@ case "$RUNTIME" in
         brew install go@1.24
         export PATH="/opt/homebrew/opt/go@1.24/bin:$PATH"
         export GOROOT="/opt/homebrew/opt/go@1.24/libexec"
-        # Use GITHUB_PATH to prepend without clobbering the existing PATH
-        echo "/opt/homebrew/opt/go@1.24/bin" >> $GITHUB_PATH
+        echo "PATH=$PATH" >> $GITHUB_ENV
         echo "GOROOT=$GOROOT" >> $GITHUB_ENV
         ;;
       *)

--- a/shared-scripts/setup-runtime.sh
+++ b/shared-scripts/setup-runtime.sh
@@ -70,15 +70,15 @@ case "$RUNTIME" in
         # Set up Go 1.21 as default (keg-only formula)
         export PATH="/opt/homebrew/opt/go@1.21/bin:$PATH"
         export GOROOT="/opt/homebrew/opt/go@1.21/libexec"
-        # Persist environment variables for subsequent steps
-        echo "PATH=$PATH" >> $GITHUB_ENV
+        # Use GITHUB_PATH to prepend without clobbering the existing PATH
+        echo "/opt/homebrew/opt/go@1.21/bin" >> $GITHUB_PATH
         echo "GOROOT=$GOROOT" >> $GITHUB_ENV
         ;;
       *)
         echo "Go is already installed on $OS"
         ;;
     esac
-    
+
     echo "Installed Go version:"
     go version
     ;;
@@ -89,7 +89,8 @@ case "$RUNTIME" in
         brew install go@1.24
         export PATH="/opt/homebrew/opt/go@1.24/bin:$PATH"
         export GOROOT="/opt/homebrew/opt/go@1.24/libexec"
-        echo "PATH=$PATH" >> $GITHUB_ENV
+        # Use GITHUB_PATH to prepend without clobbering the existing PATH
+        echo "/opt/homebrew/opt/go@1.24/bin" >> $GITHUB_PATH
         echo "GOROOT=$GOROOT" >> $GITHUB_ENV
         ;;
       *)
@@ -108,16 +109,16 @@ case "$RUNTIME" in
         ./rustup-init.exe -y --default-toolchain stable --profile minimal
         # Add cargo to PATH for this session
         export PATH="$HOME/.cargo/bin:$PATH"
-        # Persist PATH for subsequent steps
-        echo "PATH=$PATH" >> $GITHUB_ENV
+        # Use GITHUB_PATH to prepend without clobbering the existing PATH
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
         ;;
       *)
         # Install Rust on Unix-like systems using rustup
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
         # Source cargo environment
         source "$HOME/.cargo/env"
-        # Persist PATH for subsequent steps
-        echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
+        # Use GITHUB_PATH to prepend without clobbering the existing PATH
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
         ;;
     esac
     echo "Installed Rust version:"
@@ -132,8 +133,8 @@ case "$RUNTIME" in
         curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "$(pwd)"
         # Add current directory to PATH for this session
         export PATH="$(pwd):$PATH"
-        # Persist PATH for subsequent steps
-        echo "PATH=$PATH" >> $GITHUB_ENV
+        # Use GITHUB_PATH to prepend without clobbering the existing PATH
+        echo "$(pwd)" >> $GITHUB_PATH
         ;;
       *)
         # Install Syft on Unix-like systems using the official installation script


### PR DESCRIPTION
## Summary

- On Windows, `setup-runtime.sh` wrote the full PATH to `GITHUB_ENV` with `echo "PATH=$PATH"`. This replaces the entire PATH with bash-style paths (`/c/...`), and since Python's `subprocess.run(cmd, shell=True)` uses `cmd.exe` on Windows, tools like `npx` become unresolvable.
- Switched all instances to use `GITHUB_PATH` which **prepends** directories without clobbering the existing PATH.
- Affects: `cargo-stable` (all OSes), `go-1.21` (macOS), `go-latest` (macOS), `syft` (Windows)

## Root cause

`cargo-stable` on Windows failed with `'npx' is not recognized` because Node.js was dropped from the PATH after `setup-runtime.sh` overwrote it.

## Test plan

- [ ] `cargo-stable` passes on Windows (was failing with `npx` not found)
- [ ] `cargo-stable` passes on Ubuntu and macOS
- [ ] `go-1.21` and `go-latest` still pass on macOS
- [ ] `syft` still passes on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)