### PR TITLE
fix(ci): cargo timeout and gradle-groovy simplification

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,6 +90,7 @@ jobs:
     env:
       TRUSTIFY_DA_DEV_MODE: true
       TRUSTIFY_DA_BACKEND_URL: 'https://exhort.stage.devshift.net'
+      JAVA_TOOL_OPTIONS: '-Dtrustify.cargo.timeout.seconds=120'
       PYTHONIOENCODING: utf-8
       PYTHONUNBUFFERED: 1
     strategy:


### PR DESCRIPTION
## Summary

- Sets `JAVA_TOOL_OPTIONS=-Dtrustify.cargo.timeout.seconds=120` in CI env so Windows runners have enough time for `cargo metadata` crates.io index download
- Simplifies gradle-groovy scenario from 12 deps / 235 transitives (Quarkus stack, 117KB SBOM) to 3 deps / 6 transitives (guava, commons-io, log4j) to avoid DA backend 504 timeouts

## Test plan

- [ ] Windows cargo-stable integration tests pass
- [ ] gradle-groovy integration tests pass on all platforms (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)