### PR TITLE
feat(scripts): add unknown severity to vulnerability summary validation

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -179,7 +179,7 @@ Tests validate responses using **structural and invariant checks**:
 2. **Deterministic checks**: Verify counts match expected values exactly (direct dependencies, transitive dependencies)
 3. **Invariant checks**: Verify mathematical relationships hold:
    - `total == direct + transitive` (dependency counts)
-   - `total == critical + high + medium + low` (vulnerability counts)
+   - `total == critical + high + medium + low + unknown` (vulnerability counts)
    - `total == permissive + weakCopyleft + strongCopyleft + unknown` (license categories)
    - All counts must be non-negative
 4. **Provider checks**: Verify expected providers are present and have `ok: true` status with `code: 200`

--- a/shared-scripts/run_tests.py
+++ b/shared-scripts/run_tests.py
@@ -31,7 +31,7 @@ VALID_LICENSE_CATEGORIES = {"PERMISSIVE", "WEAK_COPYLEFT", "STRONG_COPYLEFT", "U
 
 VULN_SUMMARY_FIELDS = [
     "direct", "transitive", "total", "dependencies",
-    "critical", "high", "medium", "low",
+    "critical", "high", "medium", "low", "unknown",
     "remediations", "recommendations", "unscanned"
 ]
 
@@ -157,10 +157,10 @@ def validate_analysis(output: Dict[str, Any], spec: Dict[str, Any], analysis_typ
                 continue
 
             # Invariant: total == critical + high + medium + low
-            severity_sum = summary["critical"] + summary["high"] + summary["medium"] + summary["low"]
+            severity_sum = summary["critical"] + summary["high"] + summary["medium"] + summary["low"] + summary["unknown"]
             if summary["total"] != severity_sum:
                 print(f"  FAIL {analysis_type} {provider_name}/{source_name} "
-                      f"total ({summary['total']}) != critical+high+medium+low ({severity_sum})")
+                      f"total ({summary['total']}) != critical+high+medium+low+unknown ({severity_sum})")
                 ok = False
 
             # Invariant: direct + transitive == total

--- a/shared-scripts/run_tests.py
+++ b/shared-scripts/run_tests.py
@@ -156,7 +156,7 @@ def validate_analysis(output: Dict[str, Any], spec: Dict[str, Any], analysis_typ
             if not ok:
                 continue
 
-            # Invariant: total == critical + high + medium + low
+            # Invariant: total == critical + high + medium + low + unknown
             severity_sum = summary["critical"] + summary["high"] + summary["medium"] + summary["low"] + summary["unknown"]
             if summary["total"] != severity_sum:
                 print(f"  FAIL {analysis_type} {provider_name}/{source_name} "


### PR DESCRIPTION
## Summary

- Add `unknown` severity field to `VULN_SUMMARY_FIELDS` validation list
- Include `unknown` in the severity sum invariant check (`total == critical + high + medium + low + unknown`)
- Update `CONVENTIONS.md` to reflect the updated vulnerability count formula

## Jira

[TC-4729](https://redhat.atlassian.net/browse/TC-4729)

## Test plan

- [ ] CI syntax check passes (`python3 -m py_compile shared-scripts/*.py`)
- [ ] Integration tests pass with backends returning the `unknown` field
- [ ] Integration tests pass with backends not yet returning the `unknown` field (graceful handling)